### PR TITLE
Fix: selecting title-off option delets the menu item

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -34,7 +34,7 @@ jQuery(function ($) {
 
 		$(document).on('change', selector, function () {
 			var checkbox = $(this);
-			checkbox.closest('p').find('.mega-menu-title').prop('disabled', checkbox.is(':checked'));
+			checkbox.closest('p').find('.mega-menu-title').prop('readonly', checkbox.is(':checked'));
 		});
 		$(selector).change();
 


### PR DESCRIPTION
Fixes: #11 

Instead of making the label `disabled` I am adding `readonly` here. As when hiding the menu title in the frontend is not dependent on whether this is `disabled` or `readonly` [(see)](https://github.com/ThemeFuse/Unyson-MegaMenu-Extension/blob/master/hooks.php#L110), this works nicely.
